### PR TITLE
Upgrade BouncyCastle to 1.8.6.7

### DIFF
--- a/GooglePay.PaymentDataCryptography/GooglePay.PaymentDataCryptography.csproj
+++ b/GooglePay.PaymentDataCryptography/GooglePay.PaymentDataCryptography.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Portable.BouncyCastle" Version="1.8.4" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.8.6.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Upgrading Bouncy Castle library to 1.8.6.7. No breaking changes.