### PR TITLE
Added support for ECv2SigningOnly for validating passes callback

### DIFF
--- a/GooglePay.PaymentDataCryptography/GoogleKeyProvider.cs
+++ b/GooglePay.PaymentDataCryptography/GoogleKeyProvider.cs
@@ -34,8 +34,9 @@ namespace GooglePay.PaymentDataCryptography
     /// </summary>
     public class GoogleKeyProvider : ISignatureKeyProvider
     {
-        private const string GoogleProductionKeyUrl = "https://payments.developers.google.com/paymentmethodtoken/keys.json";
-        private const string GoogleTestKeyUrl = "https://payments.developers.google.com/paymentmethodtoken/test/keys.json";
+        public const string GoogleProductionKeyUrl = "https://payments.developers.google.com/paymentmethodtoken/keys.json";
+        public const string GoogleTestKeyUrl = "https://payments.developers.google.com/paymentmethodtoken/test/keys.json";
+        public const string GooglePassesUrl = "https://pay.google.com/gp/m/issuer/keys";
 
         private readonly Util.IClock _clock = Util.SystemClock.Default;
         private readonly string _url;
@@ -47,8 +48,13 @@ namespace GooglePay.PaymentDataCryptography
 
         private readonly string _testData = null;
 
-        public GoogleKeyProvider(bool isTest = false) =>
-            _url = isTest ? GoogleTestKeyUrl : GoogleProductionKeyUrl;
+        /// <summary>
+        /// Use the GoogleProductionKeyUrl or GoogleTestKeyUrl or GooglePassesUrl constants from this class
+        /// based on the environment and keys you require.
+        /// </summary>
+        /// <param name="url"></param>
+        public GoogleKeyProvider(string url) =>
+            _url = url;
 
         internal GoogleKeyProvider(string testData, Util.IClock mockClock) {
             _testData = testData;

--- a/GooglePay.PaymentDataCryptography/Models/PaymentData.cs
+++ b/GooglePay.PaymentDataCryptography/Models/PaymentData.cs
@@ -18,15 +18,15 @@ namespace GooglePay.PaymentDataCryptography.Models
 {
 
     [DataContract]
-    internal class PaymentData
+    public class PaymentData
     {
         [DataMember(Name = "protocolVersion")]
-        internal string ProtocolVersion { get; set; }
+        public string ProtocolVersion { get; set; }
         [DataMember(Name = "signature")]
-        internal string Signature { get; set; }
+        public string Signature { get; set; }
         [DataMember(Name = "signedMessage")]
-        internal string SignedMessage { get; set; }
+        public string SignedMessage { get; set; }
         [DataMember(Name = "intermediateSigningKey")]
-        internal SigningKey IntermediateSigningKey { get; set; }
+        public SigningKey IntermediateSigningKey { get; set; }
     }
 }

--- a/GooglePay.PaymentDataCryptography/Models/SigningKey.cs
+++ b/GooglePay.PaymentDataCryptography/Models/SigningKey.cs
@@ -17,11 +17,11 @@ using System.Runtime.Serialization;
 namespace GooglePay.PaymentDataCryptography.Models
 {
     [DataContract]
-    internal class SigningKey
+    public class SigningKey
     {
         [DataMember(Name = "signedKey")]
-        internal string SignedKey { get; set; }
+        public string SignedKey { get; set; }
         [DataMember(Name = "signatures")]
-        internal string[] Signatures { get; set; }
+        public string[] Signatures { get; set; }
     }
 }

--- a/GooglePay.PaymentDataCryptography/SignatureVerification.cs
+++ b/GooglePay.PaymentDataCryptography/SignatureVerification.cs
@@ -25,7 +25,7 @@ using Org.BouncyCastle.Utilities.Encoders;
 
 namespace GooglePay.PaymentDataCryptography
 {
-    internal class SignatureVerification
+    public class SignatureVerification
     {
         private readonly Util.IClock _clock = Util.SystemClock.Default;
 
@@ -49,6 +49,8 @@ namespace GooglePay.PaymentDataCryptography
                     return VerifyMessageECv1(keys, signedString, signatureBytes);
                 case "ECv2":
                     return VerifyMessageECv2(keys, signedString, signatureBytes, paymentData.IntermediateSigningKey);
+                case "ECv2SigningOnly":
+                    return VerifyMessageECv2SigningOnly(keys, signedString, signatureBytes, paymentData.IntermediateSigningKey);
                 default:
                     throw new SecurityException($"Unsupported protocol version {paymentData.ProtocolVersion}");
             }
@@ -75,6 +77,28 @@ namespace GooglePay.PaymentDataCryptography
                 throw new SecurityException("Expired signed key found in payload");
             }
             ECPublicKeyParameters signingKey = KeyParser.ParsePublicKeyDer(signedKey.KeyValue);
+            return VerifySignature(signingKey, signedString, signature);
+        }
+        
+        private bool VerifyMessageECv2SigningOnly(IEnumerable<string> keys, byte[] signedString, byte[] signature, Models.SigningKey intermediateSigningKey)
+        {
+            if (!intermediateSigningKey.Signatures.Any(intermediateSignature =>
+                {
+                    byte[] signatureBytes = Base64.Decode(intermediateSignature);
+                    byte[] signedSignatureString = CreateSignedString("GooglePayPasses", "ECv2SigningOnly", intermediateSigningKey.SignedKey);
+                    return keys.Any(key => VerifySignature(KeyParser.ParsePublicKeyDer(key), signedSignatureString, signatureBytes));
+                }))
+            {
+                throw new SecurityException("No valid signing keys found in payload");
+            }
+
+            Models.KeyWithExpiration signedKey = Util.Json.Parse<Models.KeyWithExpiration>(intermediateSigningKey.SignedKey);
+            if (!signedKey.Valid(_clock))
+            {
+                throw new SecurityException("Expired signed key found in payload");
+            }
+            ECPublicKeyParameters signingKey = KeyParser.ParsePublicKeyDer(signedKey.KeyValue);
+            return VerifySignature(signingKey, signedString, signature);
             return VerifySignature(signingKey, signedString, signature);
         }
 


### PR DESCRIPTION
- Added ECv2SigningOnly option
- Included the Passes Keys URL
Updated the code to take in a URL instead of using flags to determine
the server
- Made SignatureVerification.cs and associated classes public
This allows us to use this to verify a callback message.

#9 