### PR TITLE
feat: allow HTTP client customization via GoogleKeyProviderOptions

### DIFF
--- a/GooglePay.PaymentDataCryptography.Tests/GoogleKeyProviderOptionsTest.cs
+++ b/GooglePay.PaymentDataCryptography.Tests/GoogleKeyProviderOptionsTest.cs
@@ -1,0 +1,20 @@
+using Xunit;
+
+using GooglePay.PaymentDataCryptography;
+
+namespace GooglePay.PaymentDataCryptography.Tests
+{
+    public class GoogleKeyProviderOptionsTest
+    {
+        [Fact]
+        public void DefaultValues()
+        {
+            var options = new GoogleKeyProviderOptions();
+
+            Assert.False(options.IsTest);
+            Assert.Null(options.Url);
+            Assert.Null(options.CacheDuration);
+            Assert.Null(options.MessageHandler);
+        }
+    }
+}

--- a/GooglePay.PaymentDataCryptography.Tests/GoogleKeyProviderTest.cs
+++ b/GooglePay.PaymentDataCryptography.Tests/GoogleKeyProviderTest.cs
@@ -1,0 +1,218 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+using GooglePay.PaymentDataCryptography;
+
+namespace GooglePay.PaymentDataCryptography.Tests
+{
+    public class GoogleKeyProviderTest
+    {
+        private const string ValidKeyJson =
+            "{\"keys\":[{\"keyValue\":\"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPYnHwS8uegWAewQtlxizmLFynwHcxRT1PK07cDA6/C4sXrVI1SzZCUx8U8S0LjMrT6ird/VW7be3Mz6t/srtRQ==\",\"protocolVersion\":\"ECv1\"}]}";
+
+        [Fact]
+        public void NullOptions_ThrowsArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+                new GoogleKeyProvider((GoogleKeyProviderOptions)null));
+        }
+
+        [Fact]
+        public async Task DefaultOptions_UsesProductionUrl()
+        {
+            var handler = new MockHttpMessageHandler(ValidKeyJson);
+            var provider = new GoogleKeyProvider(new GoogleKeyProviderOptions
+            {
+                MessageHandler = handler
+            });
+
+            await provider.GetPublicKeys("ECv1");
+
+            Assert.Equal(
+                "https://payments.developers.google.com/paymentmethodtoken/keys.json",
+                handler.RequestUri.ToString());
+        }
+
+        [Fact]
+        public async Task IsTestTrue_UsesTestUrl()
+        {
+            var handler = new MockHttpMessageHandler(ValidKeyJson);
+            var provider = new GoogleKeyProvider(new GoogleKeyProviderOptions
+            {
+                IsTest = true,
+                MessageHandler = handler
+            });
+
+            await provider.GetPublicKeys("ECv1");
+
+            Assert.Equal(
+                "https://payments.developers.google.com/paymentmethodtoken/test/keys.json",
+                handler.RequestUri.ToString());
+        }
+
+        [Fact]
+        public async Task CustomUrl_OverridesIsTest()
+        {
+            var handler = new MockHttpMessageHandler(ValidKeyJson);
+            var provider = new GoogleKeyProvider(new GoogleKeyProviderOptions
+            {
+                IsTest = true,
+                Url = "https://custom.example.com/keys.json",
+                MessageHandler = handler
+            });
+
+            await provider.GetPublicKeys("ECv1");
+
+            Assert.Equal("https://custom.example.com/keys.json", handler.RequestUri.ToString());
+        }
+
+        [Fact]
+        public async Task CustomMessageHandler_IsUsedForRequests()
+        {
+            var handler = new MockHttpMessageHandler(ValidKeyJson);
+            var provider = new GoogleKeyProvider(new GoogleKeyProviderOptions
+            {
+                MessageHandler = handler
+            });
+
+            await provider.GetPublicKeys("ECv1");
+
+            Assert.Equal(1, handler.RequestCount);
+        }
+
+        [Fact]
+        public async Task CustomMessageHandler_ReturnsKeys()
+        {
+            var handler = new MockHttpMessageHandler(ValidKeyJson);
+            var provider = new GoogleKeyProvider(new GoogleKeyProviderOptions
+            {
+                MessageHandler = handler
+            });
+
+            var keys = await provider.GetPublicKeys("ECv1");
+
+            Assert.NotNull(keys);
+            Assert.Single(keys);
+            Assert.Equal(
+                "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPYnHwS8uegWAewQtlxizmLFynwHcxRT1PK07cDA6/C4sXrVI1SzZCUx8U8S0LjMrT6ird/VW7be3Mz6t/srtRQ==",
+                keys.First());
+        }
+
+        [Fact]
+        public async Task UnknownProtocolVersion_ReturnsNull()
+        {
+            var handler = new MockHttpMessageHandler(ValidKeyJson);
+            var provider = new GoogleKeyProvider(new GoogleKeyProviderOptions
+            {
+                MessageHandler = handler
+            });
+
+            var keys = await provider.GetPublicKeys("ECv99");
+
+            Assert.Null(keys);
+        }
+
+        [Fact]
+        public async Task CacheDurationSet_ServerMaxAgeIgnored()
+        {
+            var handler = new MockHttpMessageHandler(ValidKeyJson, maxAge: TimeSpan.Zero);
+            var provider = new GoogleKeyProvider(new GoogleKeyProviderOptions
+            {
+                CacheDuration = TimeSpan.FromDays(30),
+                MessageHandler = handler
+            });
+
+            await provider.GetPublicKeys("ECv1");
+            Assert.Equal(1, handler.RequestCount);
+
+            // Server said max-age=0 but we set 30 days — should not re-fetch
+            await provider.GetPublicKeys("ECv1");
+            Assert.Equal(1, handler.RequestCount);
+        }
+
+        [Fact]
+        public async Task NoCacheDuration_ServerMaxAgeUsed()
+        {
+            var handler = new MockHttpMessageHandler(ValidKeyJson, maxAge: TimeSpan.Zero);
+            var provider = new GoogleKeyProvider(new GoogleKeyProviderOptions
+            {
+                MessageHandler = handler
+            });
+
+            await provider.GetPublicKeys("ECv1");
+            Assert.Equal(1, handler.RequestCount);
+
+            // Server said max-age=0, no CacheDuration override — should re-fetch
+            await provider.GetPublicKeys("ECv1");
+            Assert.Equal(2, handler.RequestCount);
+        }
+
+        [Fact]
+        public async Task NoCacheControlHeader_DefaultSevenDaysUsed()
+        {
+            var handler = new MockHttpMessageHandler(ValidKeyJson, maxAge: null);
+            var provider = new GoogleKeyProvider(new GoogleKeyProviderOptions
+            {
+                MessageHandler = handler
+            });
+
+            await provider.GetPublicKeys("ECv1");
+            Assert.Equal(1, handler.RequestCount);
+
+            // No server header, default is 7 days — should use cache
+            await provider.GetPublicKeys("ECv1");
+            Assert.Equal(1, handler.RequestCount);
+        }
+
+        [Fact]
+        public async Task HttpClientReused_AcrossMultipleFetches()
+        {
+            var handler = new MockHttpMessageHandler(ValidKeyJson, maxAge: TimeSpan.Zero);
+            var provider = new GoogleKeyProvider(new GoogleKeyProviderOptions
+            {
+                MessageHandler = handler
+            });
+
+            await provider.GetPublicKeys("ECv1");
+            await provider.GetPublicKeys("ECv1");
+            await provider.GetPublicKeys("ECv1");
+
+            // All 3 fetches went through the same handler instance
+            Assert.Equal(3, handler.RequestCount);
+        }
+
+        [Fact]
+        public async Task PrefetchKeys_FetchesViaHandler()
+        {
+            var handler = new MockHttpMessageHandler(ValidKeyJson);
+            var provider = new GoogleKeyProvider(new GoogleKeyProviderOptions
+            {
+                MessageHandler = handler
+            });
+
+            await provider.PrefetchKeys();
+            Assert.Equal(1, handler.RequestCount);
+
+            // GetPublicKeys should use cached keys, no re-fetch
+            var keys = await provider.GetPublicKeys("ECv1");
+            Assert.Equal(1, handler.RequestCount);
+            Assert.NotNull(keys);
+        }
+
+        [Fact]
+        public void BackwardCompat_ParameterlessConstructor()
+        {
+            var provider = new GoogleKeyProvider();
+            Assert.NotNull(provider);
+        }
+
+        [Fact]
+        public void BackwardCompat_BoolConstructor()
+        {
+            var provider = new GoogleKeyProvider(isTest: true);
+            Assert.NotNull(provider);
+        }
+    }
+}

--- a/GooglePay.PaymentDataCryptography.Tests/MockHttpMessageHandler.cs
+++ b/GooglePay.PaymentDataCryptography.Tests/MockHttpMessageHandler.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GooglePay.PaymentDataCryptography.Tests
+{
+    internal class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _responseContent;
+        private readonly TimeSpan? _maxAge;
+
+        public Uri RequestUri { get; private set; }
+        public int RequestCount { get; private set; }
+
+        public MockHttpMessageHandler(string responseContent, TimeSpan? maxAge = null)
+        {
+            _responseContent = responseContent;
+            _maxAge = maxAge;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestUri = request.RequestUri;
+            RequestCount++;
+
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(_responseContent, Encoding.UTF8, "application/json")
+            };
+
+            if (_maxAge.HasValue)
+            {
+                response.Headers.CacheControl = new CacheControlHeaderValue
+                {
+                    MaxAge = _maxAge.Value
+                };
+            }
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/GooglePay.PaymentDataCryptography.Tests/PassCallbackValidatorTest.cs
+++ b/GooglePay.PaymentDataCryptography.Tests/PassCallbackValidatorTest.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+using GooglePay.PaymentDataCryptography;
+
+namespace GooglePay.PaymentDataCryptography.Tests
+{
+    public class PassCallbackValidatorTest
+    {
+        private const string ValidKeyJson =
+            "{\"keys\":[{\"keyValue\":\"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPYnHwS8uegWAewQtlxizmLFynwHcxRT1PK07cDA6/C4sXrVI1SzZCUx8U8S0LjMrT6ird/VW7be3Mz6t/srtRQ==\",\"protocolVersion\":\"ECv1\"}]}";
+
+        // Structurally valid payment data that will parse correctly but fail signature verification
+        private const string PaymentDataJson =
+            "{\"protocolVersion\":\"ECv1\"," +
+            "\"signedMessage\":\"{\\\"tag\\\":\\\"ZVwlJt7dU8Plk0+r8rPF8DmPTvDiOA1UAoNjDV+SqDE\\\\u003d\\\"," +
+            "\\\"ephemeralPublicKey\\\":\\\"BPhVspn70Zj2Kkgu9t8+ApEuUWsI/zos5whGCQBlgOkuYagOis7qsrcbQrcprjvTZO3XOU+Qbcc28FSgsRtcgQE\\\\u003d\\\"," +
+            "\\\"encryptedMessage\\\":\\\"12jUObueVTdy\\\"}\"," +
+            "\"signature\":\"MEQCIDxBoUCoFRGReLdZ/cABlSSRIKoOEFoU3e27c14vMZtfAiBtX3pGMEpnw6mSAbnagCCgHlCk3NcFwWYEyxIE6KGZVA\\u003d\\u003d\"}";
+
+        [Fact]
+        public void ParameterlessConstructor()
+        {
+            var validator = new PassCallbackValidator();
+            Assert.NotNull(validator);
+        }
+
+        [Fact]
+        public void NullOptions_Constructs()
+        {
+            var validator = new PassCallbackValidator((GoogleKeyProviderOptions)null);
+            Assert.NotNull(validator);
+        }
+
+        [Fact]
+        public void WithOptions_UsesGooglePassesUrl()
+        {
+            var handler = new MockHttpMessageHandler(ValidKeyJson);
+            var validator = new PassCallbackValidator(new GoogleKeyProviderOptions
+            {
+                MessageHandler = handler
+            });
+
+            // Verify triggers key fetch; signature won't match so SecurityException is expected
+            Assert.Throws<SecurityException>(() =>
+                validator.Verify("someRecipient", PaymentDataJson));
+
+            Assert.Equal("https://pay.google.com/gp/m/issuer/keys", handler.RequestUri.ToString());
+        }
+
+        [Fact]
+        public void WithOptions_IgnoresUrlAndIsTestProperties()
+        {
+            var handler = new MockHttpMessageHandler(ValidKeyJson);
+            var validator = new PassCallbackValidator(new GoogleKeyProviderOptions
+            {
+                IsTest = true,
+                Url = "https://should-be-ignored.example.com/keys.json",
+                MessageHandler = handler
+            });
+
+            Assert.Throws<SecurityException>(() =>
+                validator.Verify("someRecipient", PaymentDataJson));
+
+            // Should still use Google Passes URL, not the one from options
+            Assert.Equal("https://pay.google.com/gp/m/issuer/keys", handler.RequestUri.ToString());
+        }
+
+        [Fact]
+        public void WithOptions_ForwardsMessageHandler()
+        {
+            var handler = new MockHttpMessageHandler(ValidKeyJson);
+            var validator = new PassCallbackValidator(new GoogleKeyProviderOptions
+            {
+                MessageHandler = handler
+            });
+
+            Assert.Throws<SecurityException>(() =>
+                validator.Verify("someRecipient", PaymentDataJson));
+
+            Assert.Equal(1, handler.RequestCount);
+        }
+    }
+}

--- a/GooglePay.PaymentDataCryptography/GoogleKeyProviderOptions.cs
+++ b/GooglePay.PaymentDataCryptography/GoogleKeyProviderOptions.cs
@@ -1,0 +1,49 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Net.Http;
+
+namespace GooglePay.PaymentDataCryptography
+{
+    /// <summary>
+    /// Configuration options for <see cref="GoogleKeyProvider"/>.
+    /// </summary>
+    public class GoogleKeyProviderOptions
+    {
+        /// <summary>
+        /// When true, uses Google's test key endpoint instead of production.
+        /// Ignored if <see cref="Url"/> is set.
+        /// </summary>
+        public bool IsTest { get; set; }
+
+        /// <summary>
+        /// Custom URL for fetching signing keys. Overrides <see cref="IsTest"/> when set.
+        /// </summary>
+        public string Url { get; set; }
+
+        /// <summary>
+        /// Override the cache duration for fetched keys. When null (default),
+        /// the server's Cache-Control max-age header is used, falling back to 7 days.
+        /// </summary>
+        public TimeSpan? CacheDuration { get; set; }
+
+        /// <summary>
+        /// Custom HTTP message handler for the underlying <see cref="HttpClient"/>.
+        /// Use this to configure certificate validation, logging, retries, etc.
+        /// The handler is not owned by the provider and will not be disposed.
+        /// </summary>
+        public HttpMessageHandler MessageHandler { get; set; }
+    }
+}

--- a/GooglePay.PaymentDataCryptography/PassCallbackValidator.cs
+++ b/GooglePay.PaymentDataCryptography/PassCallbackValidator.cs
@@ -25,15 +25,32 @@ namespace GooglePay.PaymentDataCryptography
     {
         private const string GooglePassesUrl = "https://pay.google.com/gp/m/issuer/keys";
         private const string GoogleSenderId = "GooglePayPasses";
-        private readonly ISignatureKeyProvider _signatureKeyProvider = new GoogleKeyProvider(GooglePassesUrl);
-        private readonly SignatureVerification _signatureVerification = new SignatureVerification();
+        private readonly ISignatureKeyProvider _signatureKeyProvider;
+        private readonly SignatureVerification _signatureVerification;
 
-        public PassCallbackValidator()
+        public PassCallbackValidator() : this((GoogleKeyProviderOptions)null)
         {
+        }
+
+        /// <summary>
+        /// Creates a new validator with the specified options for HTTP customization.
+        /// The key URL is always the Google Passes endpoint.
+        /// </summary>
+        /// <param name="options">Configuration options (Url and IsTest are ignored)</param>
+        public PassCallbackValidator(GoogleKeyProviderOptions options)
+        {
+            _signatureKeyProvider = new GoogleKeyProvider(new GoogleKeyProviderOptions
+            {
+                Url = GooglePassesUrl,
+                CacheDuration = options?.CacheDuration,
+                MessageHandler = options?.MessageHandler
+            });
+            _signatureVerification = new SignatureVerification();
         }
 
         internal PassCallbackValidator(Util.IClock clock)
         {
+            _signatureKeyProvider = new GoogleKeyProvider(new GoogleKeyProviderOptions { Url = GooglePassesUrl });
             _signatureVerification = new SignatureVerification(clock);
         }
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ var handler = new HttpClientHandler
 {
     ServerCertificateCustomValidationCallback = (message, cert, chain, errors) =>
     {
-        // Custom certificate validation logic
-        return true;
+        // Your certificate validation logic here
+        return errors == System.Net.Security.SslPolicyErrors.None;
     }
 };
 var loggingHandler = new MyLoggingHandler(handler); // DelegatingHandler


### PR DESCRIPTION
Replaces #19 (closed due to branch history cleanup to resolve CLA check).

## Summary
- Add `GoogleKeyProviderOptions` class for customizing HTTP behavior when fetching Google's signing keys
- Update `GoogleKeyProvider` and `PassCallbackValidator` to accept options (fully backwards-compatible)
- Fix HttpClient-per-request anti-pattern by reusing a single instance
- Document new API in README

## Motivation
The library creates `HttpClient` internally with no way to customize it. This blocks scenarios like custom certificate validation and request/response logging. `HttpMessageHandler` is the standard .NET extensibility point and supports both needs via handler chaining.

## New API

### `GoogleKeyProviderOptions`

| Property | Type | Default | Description |
|----------|------|---------|-------------|
| `IsTest` | `bool` | `false` | Use Google's test key endpoint |
| `Url` | `string` | `null` | Custom key endpoint URL (overrides `IsTest`) |
| `CacheDuration` | `TimeSpan?` | `null` | Fixed cache TTL (when null, uses server `Cache-Control` or 7 days) |
| `MessageHandler` | `HttpMessageHandler` | `null` | Custom handler for the underlying `HttpClient` (not disposed by provider) |

### Usage
```csharp
var handler = new HttpClientHandler
{
    ServerCertificateCustomValidationCallback = (msg, cert, chain, errors) => { /* ... */ }
};
var logging = new LoggingDelegatingHandler(handler);

var provider = new GoogleKeyProvider(new GoogleKeyProviderOptions
{
    MessageHandler = logging,
    CacheDuration = TimeSpan.FromHours(1),
});

// PassCallbackValidator also accepts options (URL/IsTest ignored)
var validator = new PassCallbackValidator(new GoogleKeyProviderOptions
{
    MessageHandler = logging,
});
```

## Test plan
- [x] 20 new unit tests covering: options defaults, URL selection (production/test/custom), handler wiring, key retrieval, cache behavior (fixed/server-controlled/default), HttpClient reuse, PrefetchKeys, backward-compatible constructors, PassCallbackValidator forwarding
- [x] All 367 tests pass (347 existing + 20 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)